### PR TITLE
Add CODE_OF_CONDUCT, CONTRIBUTING, and CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Global code owners for the Trello MCP Server repository
+# These users will be automatically requested for review on all pull requests
+
+* @atlassian-jinhuanlei @atlassian-sarveshsadhoo @atllitskevitch @ccanoy-atl @dtbatlassian @rsu2-stack

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Global code owners for the Trello MCP Server repository
 # These users will be automatically requested for review on all pull requests
 
-* @atlassian-jinhuanlei @atlassian-sarveshsadhoo @atllitskevitch @ccanoy-atl @dtbatlassian @rsu2-stack
+* @atlassian-jinhuanlei @atlassian-sarveshsadhoo @dtbatlassian @rsu2-stack

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Submitting contributions or comments that you know to violate the intellectual property or privacy rights of others
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer. Complaints will result in a response and be reviewed and investigated in a way that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to the Trello MCP Server
+
+Thanks for your interest in contributing. Pull requests, issues, and comments are all welcome.
+
+It helps to know what lives in this repo: the documentation and public-facing assets (`README.md`, `images/`). The server itself runs as a hosted service and isn't part of this repo, so changes here are about those public-facing pieces.
+
+## Opening an issue
+
+Use [GitHub Issues](https://github.com/atlassian/trello-mcp-server/issues). If your report is really about the hosted server, authentication, or Trello itself rather than this repo, we'll point you to faster support channels.
+
+## Sending a pull request
+
+A few things that make review easier:
+
+- Keep each pull request focused on one change. Split unrelated work into separate PRs.
+- Match the existing style and structure of the file you're editing.
+- For a larger change, open an issue first so we can talk it through before you put in the work.
+
+## Contributor License Agreement
+
+Atlassian asks contributors to sign a Contributor License Agreement (CLA). It's a record that you have the right to contribute your code, documentation, or other work, and that you're willing to have it used in the project and any derivative works.
+
+Please sign the CLA before we accept your contribution:
+
+- [CLA for corporate contributors](https://opensource.atlassian.com/corporate), if you're contributing on behalf of an organization
+- [CLA for individuals](https://opensource.atlassian.com/individual), if you're contributing on your own


### PR DESCRIPTION
## Summary
- Add `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`, based on the atlassian-mcp-server templates
- Add root `CODEOWNERS` listing the review team

Checks off three items on the [Credo Checklist](https://hello.atlassian.net/wiki/spaces/~638712e9f48fbd9b62d80f9c/pages/7381421950/Credo+Checklist+trello-mcp-server) for promoting this project from Labs to Active.

## Test plan
- [ ] Confirm GitHub picks up `CODEOWNERS` and requests review from the listed handles