### PR TITLE
Add embedded-field preview rule to trello-use skill

### DIFF
--- a/skills/trello-use/SKILL.md
+++ b/skills/trello-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trello-use
-description: "**MANDATORY prerequisite** — load this BEFORE calling any Trello MCP tool (`trelloRead*`, `trelloWrite*`, `trelloSearch`). Covers the ARI id format every tool requires and the cross-cutting rules (current-user lookup, UTC date handling, Inbox vs boards, ordered creation, pagination). Skipping it causes malformed-id errors and wrong due-date/timezone results."
+description: "**MANDATORY prerequisite** — load this BEFORE calling any Trello MCP tool (`trelloRead*`, `trelloWrite*`, `trelloSearch`). Covers the ARI id format every tool requires and the cross-cutting rules (current-user lookup, UTC date handling, Inbox vs boards, ordered creation, pagination, and embedded-field previews vs full `list_*` records). Skipping it causes malformed-id errors, wrong due-date/timezone results, and answers built on truncated data."
 disable-model-invocation: false
 ---
 
@@ -80,3 +80,23 @@ All three can be issued in parallel — `pos` is per board, and distinct values 
 ## 6. Pagination
 
 Read tools that list collections use cursor pagination (`cursor` in, `pageInfo.endCursor`/`nextCursor` + `hasNextPage`/`hasMore` out). Keep paginating while `hasNextPage`/`hasMore` is true instead of assuming the first page is complete — this matters especially for `trelloReadBoard` `list`/`list_by_workspace` when filtering by `visibility` (filtered server-side per page, not globally before pagination).
+
+## 7. Embedded fields are previews
+
+Fields that nest child objects — `lists` on a board, `labels`/`comments` on a card, `cards` on a list — are capped previews, in `get` and `list_*` responses alike. `<field>HasMore: true` marks one as truncated: `listsHasMore`, `labelsHasMore`, `checklistsHasMore`, `commentsHasMore`.
+
+A count, "all X", filtering, or "is that everything?" needs every child. Fetch them with the matching action, paginate until a response reports no next page (§6), and answer from those pages.
+
+| Children you need in full | Fetch with |
+|---|---|
+| a board's lists | `trelloReadList` `list_by_board` |
+| a list's cards | `trelloReadCard` `list_by_list` |
+| a card's checklists and their items | `trelloReadChecklist` `list_by_card` |
+| a board's labels | `trelloReadBoard` `list_labels` |
+| a card's comments | `trelloReadCard` `list_comments` — **gated**: when it is absent from the advertised actions, comments are unavailable; say that plainly |
+| a card's own labels or members | no card-scoped action exists — the preview is the ceiling, so present it as partial |
+
+**Example — "how many lists does this board have?"** `trelloReadBoard` `get` returns `lists` with `listsHasMore: true`. Take the board ARI from that response to the list action, follow the cursor to the last page, then count what you collected:
+```json
+{ "tool": "trelloReadList", "action": "list_by_board", "boardId": "ari:cloud:trello::board/workspace/<workspaceObjectId>/<boardObjectId>", "cursor": "<endCursor/nextCursor from the previous page>" }
+```


### PR DESCRIPTION
## What

Adds section 7 to the `trello-use` skill: nested fields in Trello MCP responses are capped previews, so an agent needs the matching `list_*` action when the answer depends on every child.

A card `get` embeds labels and comments. A board `get` embeds lists. Each one stops at the embed cap. An agent that counts the embedded array, or reports it as the full set, gives a wrong answer on any board or card past that size. The new section names the previews, the `HasMore` flags that mark truncation, and the action that returns the whole set for each one.

## Why now

I tested the skill against a live workspace and hit the gap. `trelloReadBoard` `get` on a 7-list board is fine at default limits, but nothing in the skill told an agent what to do once a preview truncates, so the fallback was to answer from whatever the embed returned.

## Notes for review

- The section names no cap numbers. The caps live in `EMBED_LIMIT` server-side and can change; the `HasMore` flag is the stable contract.
- `list_comments` sits behind the P2 gate, so the table says to report comments as unavailable when the action is absent instead of answering from the embedded copy.
- A card's own labels and members have no card-scoped list action. The table says to present those as partial rather than complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
